### PR TITLE
[WIP]rel2abs()の修正後

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,32 @@
+branches:
+  only:
+    - master
+    - av_before
+    - av_after
+
+init:
+  - git config --global user.email 'you@example.com'
+  - git config --global user.name 'Your Name'
+  - git config --global core.autoCRLF false
+
+install:
+  # https://chocolatey.org/packages/StrawberryPerl
+  - if not exist "C:\strawberry" choco install strawberryperl --version 5.24.1.1
+  - set PATH=C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;%PATH%
+
+  - cpanm install Carton
+  - carton install
+
+build: off
+
+test_script:
+  - set PATH=C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;%PATH%
+  - carton exec prove -lr t
+
+deploy: off
+
+cache:
+  - local
+  - C:\Strawberry
+
+shallow_clone: true

--- a/lib/Minilla/ModuleMaker/ExtUtilsMakeMaker.pm
+++ b/lib/Minilla/ModuleMaker/ExtUtilsMakeMaker.pm
@@ -8,6 +8,7 @@ use Data::Dumper;
 use File::Spec::Functions qw(catdir rel2abs);
 use File::Find ();
 use TAP::Harness::Env;
+use Cwd;
 
 # This module is EXPERIMENTAL.
 # You can use this. But I may change the behaviour...
@@ -58,7 +59,7 @@ sub prereqs {
 sub run_tests {
     my $harness = TAP::Harness::Env->create({
         verbosity => 0,
-        lib       => [ map { rel2abs(catdir(qw/blib/, $_)) } qw/arch lib/ ],
+        lib       => [ map { rel2abs(catdir(qw/blib/, $_), cwd) } qw/arch lib/ ],
         color     => -t STDOUT
     });
     my @tests = sort +_find(qr/\.t$/, 't');

--- a/lib/Minilla/ModuleMaker/ModuleBuildTiny.pm
+++ b/lib/Minilla/ModuleMaker/ModuleBuildTiny.pm
@@ -71,6 +71,12 @@ sub prereqs {
 }
 
 sub run_tests {
+    printf STDERR "\n";
+    printf STDERR "+++ rel2abs('blib/lib')         : %s\n", rel2abs('blib/lib');
+    printf STDERR "+++ rel2abs('blib/lib', cwd)    : %s\n", rel2abs('blib/lib', cwd);
+    printf STDERR "+++ rel2abs('blib/lib', getcwd) : %s\n", rel2abs('blib/lib', getcwd);
+    printf STDERR "\n";
+
     my $harness = TAP::Harness::Env->create({
         verbosity => 0,
         lib       => [ map { rel2abs(catdir(qw/blib/, $_), cwd) } qw/arch lib/ ],

--- a/lib/Minilla/ModuleMaker/ModuleBuildTiny.pm
+++ b/lib/Minilla/ModuleMaker/ModuleBuildTiny.pm
@@ -8,6 +8,7 @@ use Data::Dumper;
 use File::Spec::Functions qw(catdir rel2abs);
 use File::Find ();
 use TAP::Harness::Env;
+use Cwd;
 
 use Moo;
 
@@ -72,7 +73,7 @@ sub prereqs {
 sub run_tests {
     my $harness = TAP::Harness::Env->create({
         verbosity => 0,
-        lib       => [ map { rel2abs(catdir(qw/blib/, $_)) } qw/arch lib/ ],
+        lib       => [ map { rel2abs(catdir(qw/blib/, $_), cwd) } qw/arch lib/ ],
         color     => -t STDOUT
     });
     my @tests = sort +_find(qr/\.t$/, 't');


### PR DESCRIPTION
abs2rel() の第2引数にCwd::cwd()を追加。

以下をみると、abs2rel()の第2引数は省略するとCwd::cwd()と同じとあるが、実際にはそうなっていない感じ。
理由はよくわからない。
https://metacpan.org/pod/File::Spec#rel2abs()


https://ci.appveyor.com/project/sago35/minilla/build/1.0.12#L136
修正前の状態だと、以下のテストが失敗する。
  * t\module_maker\eumm\run_tests.t
  * t\module_maker\eumm\run_tests.t

```
#   Failed test 'use Acme::Speciality;'
#   at t/00_compile.t line 4.
#     Tried to use 'Acme::Speciality'.
#     Error:  Can't locate Acme/Speciality.pm in @INC (you may need to install the Acme::Speciality module) (@INC contains: C:\Users\appveyor\AppData\Local\Temp\1\TQpJM_Zwu1\Acme-Speciality\blib\arch C:\Users\appveyor\AppData\Local\Temp\1\TQpJM_Zwu1\Acme-Speciality\blib\lib C:\projects\minilla\lib C:/projects/minilla/local/lib/perl5/MSWin32-x64-multi-thread C:/projects/minilla/local/lib/perl5 C:/Strawberry/perl/site/lib/MSWin32-x64-multi-thread C:/Strawberry/perl/site/lib C:/Strawberry/perl/vendor/lib C:/Strawberry/perl/lib .) at t/00_compile.t line 4.
# BEGIN failed--compilation aborted at t/00_compile.t line 4.
# Looks like you failed 1 test of 1.
        #   Failed test at t/module_maker/tiny/run_tests.t line 44.
        #          got: '256'
        #     expected: '0'
```